### PR TITLE
Issue #3169238 by mdeny: Fix notice error if kpi_analytics element has not been found in $variables['elements'] array

### DIFF
--- a/kpi_analytics.module
+++ b/kpi_analytics.module
@@ -60,7 +60,8 @@ function kpi_analytics_preprocess_block(&$variables) {
 
   if ($variables['base_plugin_id'] === 'block_content' &&
     isset($variables['content']['#block_content']) &&
-    $variables['content']['#block_content']->bundle() === 'kpi_analytics'
+    $variables['content']['#block_content']->bundle() === 'kpi_analytics' &&
+    isset($variables['elements']['kpi_analytics'])
   ) {
 
     // TODO: work on caching and preferable use the hook below to render the output.


### PR DESCRIPTION
**Related links**

- https://www.drupal.org/project/kpi_analytics/issues/3169238
- https://getopensocial.atlassian.net/browse/YANG-2535